### PR TITLE
1.0.3

### DIFF
--- a/components/BottomNav/index.tsx
+++ b/components/BottomNav/index.tsx
@@ -6,10 +6,12 @@ import {
 import ExploreIcon from '@mui/icons-material/Explore'
 import FavoriteIcon from '@mui/icons-material/Favorite'
 import Link from 'next/link'
+import { useRouter } from 'next/router'
 
 
 function BottomNav() {
-  const [value, setValue] = useState(0)
+  const router = useRouter()
+  const [value, setValue] = useState(router.pathname === '/' ? 0 : 1)
 
   return (
     <>

--- a/components/Pages/Favorite/Summary/Title.tsx
+++ b/components/Pages/Favorite/Summary/Title.tsx
@@ -1,17 +1,34 @@
-import { Box, Paper, Typography } from "@mui/material"
+import { Box, Typography } from "@mui/material"
 import { FC } from "react"
 import { Content } from "../../../../types"
 
 
-export const TitleRow: FC<{ content: Content }> = ({ content }) => {
+interface TitleRowProps {
+  expanded: boolean
+  content: Content
+}
+
+export const TitleRow: FC<TitleRowProps> = ({
+  expanded,
+  content
+}) => {
   return (
     <Box
       sx={{
         flex: 1,
         display: 'flex',
-        justifyContent: 'space-between'
+        justifyContent: 'center'
       }}
     >
+      {!expanded ?
+        <Typography
+          sx={{
+            flex: 1,
+            textAlign: 'left'
+          }}
+        >
+          Left Very Long
+        </Typography> : null}
       <Typography
         variant='h5'
         sx={{
@@ -22,6 +39,15 @@ export const TitleRow: FC<{ content: Content }> = ({ content }) => {
         {content.title}
       </Typography>
 
+      {!expanded ?
+        <Typography
+          sx={{
+            flex: 1,
+            textAlign: 'right'
+          }}
+        >
+          Right
+        </Typography> : null}
     </Box>
   )
 }

--- a/components/Pages/Favorite/Summary/Title.tsx
+++ b/components/Pages/Favorite/Summary/Title.tsx
@@ -1,6 +1,7 @@
-import { Box, Typography } from "@mui/material"
+import { Avatar, Box, Chip, Typography } from "@mui/material"
 import { FC } from "react"
 import { Content } from "../../../../types"
+import { calPosterior, SharpAvatar } from "../../utils"
 
 
 interface TitleRowProps {
@@ -12,6 +13,38 @@ export const TitleRow: FC<TitleRowProps> = ({
   expanded,
   content
 }) => {
+  const LeftChip = () =>
+    <Box sx={{ flex: 1, display: 'flex', justifyContent: 'flex-start' }}>
+      <Chip
+        avatar={<Avatar>P</Avatar>}
+        label={content.hypothesis.prior.toFixed(4)}
+        variant='outlined'
+        color='primary'
+      />
+    </Box>
+
+  const CenterText = () =>
+    <Typography
+      variant='h5'
+      sx={{ flex: 1, textAlign: 'center' }}
+    >
+      {content.title}
+    </Typography>
+
+  const RightChip = () => {
+    const posterior = calPosterior(content.evidence, content.hypothesis.prior)
+    return (
+      <Box sx={{ flex: 1, display: 'flex', justifyContent: 'flex-end' }}>
+        <Chip
+          avatar={SharpAvatar('P')}
+          label={posterior.toFixed(4)}
+          variant='outlined'
+          color='error'
+        />
+      </Box>
+    )
+  }
+
   return (
     <Box
       sx={{
@@ -20,34 +53,9 @@ export const TitleRow: FC<TitleRowProps> = ({
         justifyContent: 'center'
       }}
     >
-      {!expanded ?
-        <Typography
-          sx={{
-            flex: 1,
-            textAlign: 'left'
-          }}
-        >
-          Left Very Long
-        </Typography> : null}
-      <Typography
-        variant='h5'
-        sx={{
-          flex: 1,
-          textAlign: 'center'
-        }}
-      >
-        {content.title}
-      </Typography>
-
-      {!expanded ?
-        <Typography
-          sx={{
-            flex: 1,
-            textAlign: 'right'
-          }}
-        >
-          Right
-        </Typography> : null}
+      {!expanded ? <LeftChip /> : null}
+      <CenterText />
+      {!expanded ? <RightChip /> : null}
     </Box>
   )
 }

--- a/components/Pages/Favorite/Summary/Title.tsx
+++ b/components/Pages/Favorite/Summary/Title.tsx
@@ -1,19 +1,28 @@
-import { Paper, Typography } from "@mui/material"
+import { Box, Paper, Typography } from "@mui/material"
 import { FC } from "react"
 import { Content } from "../../../../types"
 
 
 export const TitleRow: FC<{ content: Content }> = ({ content }) => {
   return (
-    <Paper
-      elevation={1}
-      variant='outlined'
-      sx={{ p: 1, textAlign: 'center' }}
+    <Box
+      sx={{
+        flex: 1,
+        display: 'flex',
+        justifyContent: 'space-between'
+      }}
     >
-      <Typography variant='h5'>
+      <Typography
+        variant='h5'
+        sx={{
+          flex: 1,
+          textAlign: 'center'
+        }}
+      >
         {content.title}
       </Typography>
-    </Paper>
+
+    </Box>
   )
 }
 

--- a/components/Pages/Favorite/Summary/Title.tsx
+++ b/components/Pages/Favorite/Summary/Title.tsx
@@ -14,18 +14,15 @@ export const TitleRow: FC<TitleRowProps> = ({
   content
 }) => {
   const LeftChip = () =>
-    <Box sx={{ flex: 1, display: 'flex', justifyContent: 'flex-start' }}>
-      <Chip
-        avatar={<Avatar>P</Avatar>}
-        label={content.hypothesis.prior.toFixed(4)}
-        variant='outlined'
-        color='primary'
-      />
-    </Box>
+    <Chip
+      avatar={<Avatar>P</Avatar>}
+      label={content.hypothesis.prior.toFixed(4)}
+      variant='outlined'
+      color='primary'
+    />
 
   const CenterText = () =>
     <Typography
-      variant='h5'
       sx={{ flex: 1, textAlign: 'center' }}
     >
       {content.title}
@@ -34,14 +31,12 @@ export const TitleRow: FC<TitleRowProps> = ({
   const RightChip = () => {
     const posterior = calPosterior(content.evidence, content.hypothesis.prior)
     return (
-      <Box sx={{ flex: 1, display: 'flex', justifyContent: 'flex-end' }}>
-        <Chip
-          avatar={SharpAvatar('P')}
-          label={posterior.toFixed(4)}
-          variant='outlined'
-          color='error'
-        />
-      </Box>
+      <Chip
+        avatar={SharpAvatar('P')}
+        label={posterior.toFixed(4)}
+        variant='outlined'
+        color='error'
+      />
     )
   }
 
@@ -50,7 +45,8 @@ export const TitleRow: FC<TitleRowProps> = ({
       sx={{
         flex: 1,
         display: 'flex',
-        justifyContent: 'center'
+        justifyContent: 'center',
+        alignItems: 'baseline'
       }}
     >
       {!expanded ? <LeftChip /> : null}

--- a/components/Pages/Favorite/Summary/index.tsx
+++ b/components/Pages/Favorite/Summary/index.tsx
@@ -1,5 +1,5 @@
-import { Paper } from "@mui/material"
-import { FC } from "react"
+import { Accordion, AccordionDetails, AccordionSummary, Box, Paper, Typography } from "@mui/material"
+import { FC, useState } from "react"
 import { Content } from "../../../../types"
 import { TitleRow } from "./Title"
 import { PosteriorRow } from "./Posterior"
@@ -13,22 +13,26 @@ interface SummaryProps {
 }
 
 const Summary: FC<SummaryProps> = ({ content }) => {
+  const [expanded, setExpanded] = useState(false)
+
   return (
-    <Paper
-      key={content.title}
+    <Accordion
+      disableGutters
       elevation={1}
-      sx={{
-        m: 1,
-        p: 1,
-        textAlign: 'left'
-      }}
+      sx={{ m: 1 }}
+      expanded={expanded}
+      onChange={(_, isExpanded) => setExpanded(isExpanded)}
     >
-      <TitleRow {...{ content }} />
-      <PosteriorRow {...{ content }} />
-      <HypothesisRow {...{ content }} />
-      <EvidenceRows {...{ content }} />
-      <OperationRow {...{ content }} />
-    </Paper>
+      <AccordionSummary  >
+        <TitleRow {...{ content }} />
+      </AccordionSummary>
+      <AccordionDetails>
+        <PosteriorRow {...{ content }} />
+        <HypothesisRow {...{ content }} />
+        <EvidenceRows {...{ content }} />
+        <OperationRow {...{ content }} />
+      </AccordionDetails>
+    </Accordion>
   )
 }
 

--- a/components/Pages/Favorite/Summary/index.tsx
+++ b/components/Pages/Favorite/Summary/index.tsx
@@ -24,7 +24,7 @@ const Summary: FC<SummaryProps> = ({ content }) => {
       onChange={(_, isExpanded) => setExpanded(isExpanded)}
     >
       <AccordionSummary  >
-        <TitleRow {...{ content }} />
+        <TitleRow {...{ expanded, content }} />
       </AccordionSummary>
       <AccordionDetails>
         <PosteriorRow {...{ content }} />

--- a/components/Pages/Favorite/Summary/index.tsx
+++ b/components/Pages/Favorite/Summary/index.tsx
@@ -1,4 +1,4 @@
-import { Accordion, AccordionDetails, AccordionSummary, Box, Paper, Typography } from "@mui/material"
+import { Accordion, AccordionDetails, AccordionSummary } from "@mui/material"
 import { FC, useState } from "react"
 import { Content } from "../../../../types"
 import { TitleRow } from "./Title"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bayes-domain",
-  "version": "1.0.3-dev",
+  "version": "1.0.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bayes-domain",
-  "version": "1.0.2",
+  "version": "1.0.3-dev",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
- fix: incorrect bottom nav initial value if url is not /
- layout: accordion for Favorite entries
- layout: if favorite entry collapsed shwo Avatar two side
- layout: display prior and posterior at both ends
- layout: fix flex-grow and alignment of the three items
- proj: pump to 1.0.3
